### PR TITLE
Update GPSDontWorkforCasting.csproj

### DIFF
--- a/GPSDontWorkforCasting/GPSDontWorkforCasting.csproj
+++ b/GPSDontWorkforCasting/GPSDontWorkforCasting.csproj
@@ -67,5 +67,10 @@
 	    <Version>121.3.0.5</Version>
 	  </PackageReference>
 	</ItemGroup>
+	<ItemGroup Condition="( '$(TargetFramework)' == 'net8.0-android' )">
+		<PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.0" />
+		<PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.0" />
+		<PackageReference Include="Xamarin.AndroidX.Preference" Version="1.2.1.3" />		
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
fix for nuget errors

add

```xml
	<ItemGroup Condition="( '$(TargetFramework)' == 'net8.0-android' )">
		<PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.0" />
		<PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.0" />
		<PackageReference Include="Xamarin.AndroidX.Preference" Version="1.2.1.3" />		
	</ItemGroup>
```